### PR TITLE
support IE implementation of indexedDB and running the code inside a google chrome packaged webapp

### DIFF
--- a/dist/localForage.js
+++ b/dist/localForage.js
@@ -86,8 +86,6 @@
 
   function setItem(key, value, callback) {
     withStore('readwrite', function setItemBody(store) {
-      if (value === null)
-        value = undefined;
       var req = store.put(value, key);
       if (callback) {
         req.onsuccess = function setItemOnSuccess() {

--- a/src/asyncStorage.js
+++ b/src/asyncStorage.js
@@ -86,8 +86,6 @@
 
   function setItem(key, value, callback) {
     withStore('readwrite', function setItemBody(store) {
-      if (value === null)
-        value = undefined;
       var req = store.put(value, key);
       if (callback) {
         req.onsuccess = function setItemOnSuccess() {


### PR DESCRIPTION
- IE implementation of indexedDB does not support putting null values (tested on IE11), this commit make it put undefined value instead of null value
  <br>
- google chrome packaged webapp aren't allowed to access window.localStorage API which can throw an exception and stop loading the file:<br>
  "    Uncaught window.localStorage is not available in packaged apps. Use chrome.storage.local instead. extensions::platformApp:14"<br>
  "    Uncaught ReferenceError: localForage is not defined "<br>
  <br>
  the commit will set localStorage to undefined when running inside an google chrome packaged webapp without exec
  "localStorage = window.localStorage;"
