### PR TITLE
Fix the syntax of the bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,12 @@
         "dist/backbone.localforage.min.js"
     ],
     "ignore": [
-        ".travis.yml"
+        ".travis.yml",
         "build.sh",
         "CONTRIBUTING.md",
         "LICENSE",
         "Makefile",
-        "test*"
+        "test*",
         "vendor/*"
     ],
     "dependencies": {},


### PR DESCRIPTION
The `bower.json` file has syntax errors which prevent the module from being installed with bower.
