### PR TITLE
Removed "LIMIT 1" from removeItem function.

### DIFF
--- a/src/drivers/websql.js
+++ b/src/drivers/websql.js
@@ -93,7 +93,7 @@
     function removeItem(key, callback) {
         return new Promise(function(resolve, reject) {
             db.transaction(function (t) {
-                t.executeSql('DELETE FROM localforage WHERE key = ? LIMIT 1', [key], function() {
+                t.executeSql('DELETE FROM localforage WHERE key = ?', [key], function() {
                     if (callback) {
                         callback();
                     }


### PR DESCRIPTION
"LIMIT 1" creates a SQLError "could not prepare statement (1 near "LIMIT": syntax error)".
