### PR TITLE
Use reject on errors with indexeddb

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -56,13 +56,14 @@
         return;
     }
 
-    function withStore(type, f) {
+    function withStore(type, f, reject) {
         if (db) {
             f(db.transaction(STORENAME, type).objectStore(STORENAME));
         } else {
             var openreq = indexedDB.open(DBNAME, DBVERSION);
             openreq.onerror = function withStoreOnError() {
                 console.error("asyncStorage: can't open database:", openreq.error.name);
+                reject(openreq.error.name);
             };
             openreq.onupgradeneeded = function withStoreOnUpgradeNeeded() {
                 // First time setup: create an empty object store
@@ -93,8 +94,9 @@
                 };
                 req.onerror = function getItemOnError() {
                     console.error('Error in asyncStorage.getItem(): ', req.error.name);
+                    reject(req.error.name);
                 };
-            });
+            }, reject);
         });
     }
 
@@ -120,8 +122,9 @@
                 };
                 req.onerror = function setItemOnError() {
                     console.error('Error in asyncStorage.setItem(): ', req.error.name);
+                    reject(req.error.name);
                 };
-            });
+            }, reject);
         });
     }
 
@@ -147,6 +150,7 @@
                 };
                 req.onerror = function removeItemOnError() {
                     console.error('Error in asyncStorage.removeItem(): ', req.error.name);
+                    reject(req.error.name);
                 };
             });
         });
@@ -166,7 +170,7 @@
                 req.onerror = function clearOnError() {
                     console.error('Error in asyncStorage.clear(): ', req.error.name);
                 };
-            });
+            }, reject);
         });
     }
 
@@ -183,6 +187,7 @@
                 };
                 req.onerror = function lengthOnError() {
                     console.error('Error in asyncStorage.length(): ', req.error.name);
+                    reject(req.error.name);
                 };
             });
         });
@@ -240,8 +245,9 @@
 
                 req.onerror = function keyOnError() {
                     console.error('Error in asyncStorage.key(): ', req.error.name);
+                    reject(req.error.name);
                 };
-            });
+            }, reject);
         });
     }
 


### PR DESCRIPTION
The indexeddb driver logs errors to the console but doesn't use reject, and there is no way to catch thoses because they are not thrown either...
It would help manage the bug https://github.com/mozilla/localForage/issues/70
