### PR TITLE
Detect and avoid old indexedDB implementation

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -114,9 +114,9 @@
     };
 
     var storageLibrary;
-    // Check to see if IndexedDB is available; it's our preferred backend
-    // library.
-    if (indexedDB) {
+    // Check to see if IndexedDB is available and if it is the latest
+    // implementation; it's our preferred backend library.
+    if (indexedDB && indexedDB.open('localforage', 1).onupgradeneeded === null ) {
         storageLibrary = localForage.INDEXEDDB;
     } else if (openDatabase) { // WebSQL is available, so we'll use that.
         storageLibrary = localForage.WEBSQL;


### PR DESCRIPTION
Some Samsung Android devices provide support for and old indexedDB
implementation which is not compatible with the latest spec. Fixes #128
