### PR TITLE
feat(websql): add reject to _initStorage when openDatabase fails

### DIFF
--- a/src/drivers/websql.js
+++ b/src/drivers/websql.js
@@ -63,7 +63,7 @@
                 db = openDatabase(dbInfo.name, dbInfo.version,
                                   dbInfo.description, dbInfo.size);
             } catch (e) {
-                return _this.setDriver('localStorageWrapper').then(resolve);
+                return _this.setDriver('localStorageWrapper').then(resolve, reject);
             }
 
             // Create our key/value table if it doesn't exist.


### PR DESCRIPTION
This seems to be the last `.then()` without a reject code.
