### PR TITLE
feat: use catch on promises to handle exceptions inside then

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -73,7 +73,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -115,7 +115,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -160,7 +160,7 @@
                         reject(error);
                     }
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -185,7 +185,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -212,7 +212,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -280,7 +280,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -318,7 +318,7 @@
 
                     reject(req.error);
                 };
-            }, reject);
+            }).catch(reject);
         });
     }
 

--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -74,7 +74,7 @@
                 }
 
                 resolve();
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -108,7 +108,7 @@
 
                     reject(e);
                 }
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -133,7 +133,7 @@
                     callback(result);
                 }
                 resolve(result);
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -153,7 +153,7 @@
                 }
 
                 resolve(keys);
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -169,7 +169,7 @@
                 }
 
                 resolve(result);
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -185,7 +185,7 @@
                 }
 
                 resolve();
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -391,7 +391,7 @@
                         resolve(originalValue);
                     }
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 

--- a/src/drivers/websql.js
+++ b/src/drivers/websql.js
@@ -106,7 +106,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -162,7 +162,7 @@
                         });
                     }
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -186,7 +186,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -211,7 +211,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -240,7 +240,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -273,7 +273,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 
@@ -304,7 +304,7 @@
                         reject(error);
                     });
                 });
-            }, reject);
+            }).catch(reject);
         });
     }
 

--- a/src/localforage.js
+++ b/src/localforage.js
@@ -140,7 +140,7 @@
                     }
 
                     localForage._ready.then(resolve, reject);
-                }, reject);
+                }).catch(reject);
             });
 
             ready.then(callback, callback);


### PR DESCRIPTION
Beyond the syntactic sugar, it will properly reject even if the success function (of a `then`) throws an uncaught exception.
Closes #233
