### PR TITLE
fix(api): properly resolve the promise if a callback throws an Error

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -162,10 +162,6 @@
                     var error = new Error('No available storage method found.');
                     self._driverSet = Promise.reject(error);
 
-                    if (errorCallback) {
-                        errorCallback(error);
-                    }
-
                     reject(error);
 
                     return;
@@ -179,9 +175,6 @@
                     require([driverName], function(lib) {
                         self._extend(lib);
 
-                        if (callback) {
-                            callback();
-                        }
                         resolve();
                     });
 
@@ -205,12 +198,10 @@
                     self._extend(_this[driverName]);
                 }
 
-                if (callback) {
-                    callback();
-                }
-
                 resolve();
             });
+
+            this._driverSet.then(callback, errorCallback);
 
             return this._driverSet;
         },

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -419,6 +419,72 @@ DRIVERS.forEach(function(driverName) {
         });
     });
 
+    describe(driverName + ' driver when the callback throws an Error', function() {
+        'use strict';
+        
+        var testObj = {
+            throwFunc: function() {
+                testObj.throwFuncCalls++;
+                throw new Error('Thrown test error');
+            },
+            throwFuncCalls: 0
+        };
+
+        beforeEach(function(done) {
+            testObj.throwFuncCalls = 0;
+            done();
+        });
+
+        it('resolves the promise of getItem()', function(done) {
+            localforage.getItem('key', testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of setItem()', function(done) {
+            localforage.setItem('key', 'test', testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of clear()', function(done) {
+            localforage.clear(testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of length()', function(done) {
+            localforage.length(testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of removeItem()', function(done) {
+            localforage.removeItem('key', testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of key()', function(done) {
+            localforage.key('key', testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+
+        it('resolves the promise of keys()', function(done) {
+            localforage.keys(testObj.throwFunc).then(function() {
+                expect(testObj.throwFuncCalls).to.be(1);
+                done();
+            });
+        });
+    });
+
     describe(driverName + ' driver when ready() gets rejected', function() {
         'use strict';
 


### PR DESCRIPTION
Fixes #238 

Also abstracts the callback API to internally use the promises.
As a result we no longer need to resolve(result) & callback(result) or reject(error) & callback(null, error).
