### PR TITLE
Fix an issue with testing for indexeddb in safari in an iframe.

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -60,12 +60,16 @@
         var result = {};
 
         result[DriverType.WEBSQL] = !!_this.openDatabase;
-        result[DriverType.INDEXEDDB] = !!(
-            indexedDB &&
-            typeof indexedDB.open === 'function' &&
-            indexedDB.open('_localforage_spec_test', 1)
-                     .onupgradeneeded === null
-        );
+        result[DriverType.INDEXEDDB] = !!(function() {
+            try {
+                return (indexedDB &&
+                        typeof indexedDB.open === 'function' &&
+                        indexedDB.open('_localforage_spec_test', 1)
+                        .onupgradeneeded === null);
+            } catch (e) {
+                return false;
+            }
+        })();
 
         result[DriverType.LOCALSTORAGE] = !!(function() {
             try {


### PR DESCRIPTION
Latest safari is throwing a security error when this check is done from an iframe.
