### PR TITLE
make bower.json main point to dist/localforage.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "localforage",
   "version": "0.9.2",
   "main": [
-    "dist/localforage.min.js"
+    "dist/localforage.js"
   ],
   "ignore": [
     ".travis.yml",


### PR DESCRIPTION
I noticed that the `main` in your `bower.json` points to the minified version instead of the unminified one. I think most people (like me) work in production environments where dependencies are included in the `index.html` automatically according to the `main` property in the `bower.json` and minifcation is done in the build process. Developers who don't have an automated setup have to include their dependencies manually anywas. Therefore I'd recommend to include the unminified version in the `bower.json`. 
What do you guys think?

This is my first pull-request and I read your contribution terms (https://github.com/mozilla/localForage/blob/master/CONTRIBUTING.md). I hope I got everything right, if not please let me know, I'll be happy to fix it!
