### PR TITLE
Simpler test for outdated IndexedDB spec

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -89,8 +89,9 @@
             try {
                 return (indexedDB &&
                         typeof indexedDB.open === 'function' &&
-                        indexedDB.open('_localforage_spec_test', 1)
-                        .onupgradeneeded === null);
+                        // some Samsung/HTC Android 4.0-4.3 devices
+                        // have older IndexedDB specs
+                        typeof IDBKeyRange === 'function';
             } catch (e) {
                 return false;
             }


### PR DESCRIPTION
Related to #128 and https://github.com/pouchdb/pouchdb/issues/2810.

We used to do the `onupgradeneeded` check in PouchDB as well, but then I discovered recently that those same Samsung/HTC devices also don't have any of the standard `window.IDB*` variables defined. So you can just check for those, instead of needing to create an empty database.

I encourage you to grab a Samsung S3 or HTC One with Android 4.3 to test this, but so far this seems to be an equally reliable test.
