### PR TITLE
fixes driverSupport

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -87,8 +87,8 @@
             // as Safari. Oh the lulz...
             if (typeof self.openDatabase !== 'undefined' && self.navigator &&
                 self.navigator.userAgent &&
-                /Safari/.test(navigator.userAgent) &&
-                !/Chrome/.test(navigator.userAgent)) {
+                /Safari/.test(self.navigator.userAgent) &&
+                !/Chrome/.test(self.navigator.userAgent)) {
                 return false;
             }
             try {
@@ -98,7 +98,7 @@
                        // have older IndexedDB specs; if this isn't available
                        // their IndexedDB is too old for us to use.
                        // (Replaces the onupgradeneeded test.)
-                       typeof IDBKeyRange === 'function';
+                       typeof self.IDBKeyRange !== 'undefined';
             } catch (e) {
                 return false;
             }
@@ -106,9 +106,9 @@
 
         result[DriverType.LOCALSTORAGE] = !!(function() {
             try {
-                return (localStorage &&
-                        ('setItem' in localStorage) &&
-                        (localStorage.setItem));
+                return (self.localStorage &&
+                        ('setItem' in self.localStorage) &&
+                        (self.localStorage.setItem));
             } catch (e) {
                 return false;
             }


### PR DESCRIPTION
In IE falsely reports IndexedDB as unavailable. Because in IE `typeof self.IDBKeyRange === 'object'`
