### PR TITLE
chore(grunt): change to grunt-jscs and upgrade to 0.8.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.5.0",
     "grunt-es3-safe-recast": "^0.1.0",
-    "grunt-jscs-checker": "^0.4.4",
+    "grunt-jscs": "^0.8.0",
     "grunt-mocha": "^0.4.10",
     "grunt-saucelabs": "^5.1.2",
     "grunt-shell": "^0.6.4",


### PR DESCRIPTION
Minor update as it's only about jscs; grunt-jscs-checker has been renamed to grunt-jscs. 
I also update to use 0.8.\* version.
No change where necessary
