### PR TITLE
Simplified Promise logic for localStorage driver - closes #307

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -66,20 +66,16 @@
     // the app's key/value store!
     function clear(callback) {
         var self = this;
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                var keyPrefix = self._dbInfo.keyPrefix;
+        var promise = self.ready().then(function() {
+            var keyPrefix = self._dbInfo.keyPrefix;
 
-                for (var i = localStorage.length - 1; i >= 0; i--) {
-                    var key = localStorage.key(i);
+            for (var i = localStorage.length - 1; i >= 0; i--) {
+                var key = localStorage.key(i);
 
-                    if (key.indexOf(keyPrefix) === 0) {
-                        localStorage.removeItem(key);
-                    }
+                if (key.indexOf(keyPrefix) === 0) {
+                    localStorage.removeItem(key);
                 }
-
-                resolve();
-            }).catch(reject);
+            }
         });
 
         executeCallback(promise, callback);
@@ -99,25 +95,19 @@
             key = String(key);
         }
 
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                try {
-                    var dbInfo = self._dbInfo;
-                    var result = localStorage.getItem(dbInfo.keyPrefix + key);
+        var promise = self.ready().then(function() {
+            var dbInfo = self._dbInfo;
+            var result = localStorage.getItem(dbInfo.keyPrefix + key);
 
-                    // If a result was found, parse it from the serialized
-                    // string into a JS object. If result isn't truthy, the key
-                    // is likely undefined and we'll pass it straight to the
-                    // callback.
-                    if (result) {
-                        result = _deserialize(result);
-                    }
+            // If a result was found, parse it from the serialized
+            // string into a JS object. If result isn't truthy, the key
+            // is likely undefined and we'll pass it straight to the
+            // callback.
+            if (result) {
+                result = _deserialize(result);
+            }
 
-                    resolve(result);
-                } catch (e) {
-                    reject(e);
-                }
-            }).catch(reject);
+            return result;
         });
 
         executeCallback(promise, callback);
@@ -128,38 +118,29 @@
     function iterate(iterator, callback) {
         var self = this;
 
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                try {
-                    var keyPrefix = self._dbInfo.keyPrefix;
-                    var keyPrefixLength = keyPrefix.length;
-                    var length = localStorage.length;
+        var promise = self.ready().then(function() {
+            var keyPrefix = self._dbInfo.keyPrefix;
+            var keyPrefixLength = keyPrefix.length;
+            var length = localStorage.length;
 
-                    for (var i = 0; i < length; i++) {
-                        var key = localStorage.key(i);
-                        var value = localStorage.getItem(key);
+            for (var i = 0; i < length; i++) {
+                var key = localStorage.key(i);
+                var value = localStorage.getItem(key);
 
-                        // If a result was found, parse it from the serialized
-                        // string into a JS object. If result isn't truthy, the
-                        // key is likely undefined and we'll pass it straight
-                        // to the iterator.
-                        if (value) {
-                            value = _deserialize(value);
-                        }
-
-                        value = iterator(value, key.substring(keyPrefixLength));
-
-                        if (value !== void(0)) {
-                            resolve(value);
-                            return;
-                        }
-                    }
-
-                    resolve();
-                } catch (e) {
-                    reject(e);
+                // If a result was found, parse it from the serialized
+                // string into a JS object. If result isn't truthy, the
+                // key is likely undefined and we'll pass it straight
+                // to the iterator.
+                if (value) {
+                    value = _deserialize(value);
                 }
-            }).catch(reject);
+
+                value = iterator(value, key.substring(keyPrefixLength));
+
+                if (value !== void(0)) {
+                    return value;
+                }
+            }
         });
 
         executeCallback(promise, callback);
@@ -169,23 +150,21 @@
     // Same as localStorage's key() method, except takes a callback.
     function key(n, callback) {
         var self = this;
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                var dbInfo = self._dbInfo;
-                var result;
-                try {
-                    result = localStorage.key(n);
-                } catch (error) {
-                    result = null;
-                }
+        var promise = self.ready().then(function() {
+            var dbInfo = self._dbInfo;
+            var result;
+            try {
+                result = localStorage.key(n);
+            } catch (error) {
+                result = null;
+            }
 
-                // Remove the prefix from the key, if a key is found.
-                if (result) {
-                    result = result.substring(dbInfo.keyPrefix.length);
-                }
+            // Remove the prefix from the key, if a key is found.
+            if (result) {
+                result = result.substring(dbInfo.keyPrefix.length);
+            }
 
-                resolve(result);
-            }).catch(reject);
+            return result;
         });
 
         executeCallback(promise, callback);
@@ -194,20 +173,18 @@
 
     function keys(callback) {
         var self = this;
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                var dbInfo = self._dbInfo;
-                var length = localStorage.length;
-                var keys = [];
+        var promise = self.ready().then(function() {
+            var dbInfo = self._dbInfo;
+            var length = localStorage.length;
+            var keys = [];
 
-                for (var i = 0; i < length; i++) {
-                    if (localStorage.key(i).indexOf(dbInfo.keyPrefix) === 0) {
-                        keys.push(localStorage.key(i).substring(dbInfo.keyPrefix.length));
-                    }
+            for (var i = 0; i < length; i++) {
+                if (localStorage.key(i).indexOf(dbInfo.keyPrefix) === 0) {
+                    keys.push(localStorage.key(i).substring(dbInfo.keyPrefix.length));
                 }
+            }
 
-                resolve(keys);
-            }).catch(reject);
+            return keys;
         });
 
         executeCallback(promise, callback);
@@ -217,10 +194,8 @@
     // Supply the number of keys in the datastore to the callback function.
     function length(callback) {
         var self = this;
-        var promise = new Promise(function(resolve, reject) {
-            self.keys().then(function(keys) {
-                resolve(keys.length);
-            }).catch(reject);
+        var promise = self.keys().then(function(keys) {
+            return keys.length;
         });
 
         executeCallback(promise, callback);
@@ -238,13 +213,9 @@
             key = String(key);
         }
 
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                var dbInfo = self._dbInfo;
-                localStorage.removeItem(dbInfo.keyPrefix + key);
-
-                resolve();
-            }).catch(reject);
+        var promise = self.ready().then(function() {
+            var dbInfo = self._dbInfo;
+            localStorage.removeItem(dbInfo.keyPrefix + key);
         });
 
         executeCallback(promise, callback);
@@ -420,37 +391,35 @@
             key = String(key);
         }
 
-        var promise = new Promise(function(resolve, reject) {
-            self.ready().then(function() {
-                // Convert undefined values to null.
-                // https://github.com/mozilla/localForage/pull/42
-                if (value === undefined) {
-                    value = null;
-                }
+        var promise = self.ready().then(function() {
+            // Convert undefined values to null.
+            // https://github.com/mozilla/localForage/pull/42
+            if (value === undefined) {
+                value = null;
+            }
 
-                // Save the original value to pass to the callback.
-                var originalValue = value;
+            // Save the original value to pass to the callback.
+            var originalValue = value;
 
-                _serialize(value, function(value, error) {
-                    if (error) {
-                        reject(error);
-                    } else {
-                        try {
-                            var dbInfo = self._dbInfo;
-                            localStorage.setItem(dbInfo.keyPrefix + key, value);
-                        } catch (e) {
-                            // localStorage capacity exceeded.
-                            // TODO: Make this a specific error/event.
-                            if (e.name === 'QuotaExceededError' ||
-                                e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
-                                reject(e);
-                            }
+            _serialize(value, function(value, error) {
+                if (error) {
+                    throw error;
+                } else {
+                    try {
+                        var dbInfo = self._dbInfo;
+                        localStorage.setItem(dbInfo.keyPrefix + key, value);
+                    } catch (e) {
+                        // localStorage capacity exceeded.
+                        // TODO: Make this a specific error/event.
+                        if (e.name === 'QuotaExceededError' ||
+                            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+                            throw e;
                         }
-
-                        resolve(originalValue);
                     }
-                });
-            }).catch(reject);
+                }
+            });
+
+            return originalValue;
         });
 
         executeCallback(promise, callback);

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -755,6 +755,11 @@ DRIVERS.forEach(function(driverName) {
         'use strict';
 
         var _oldReady;
+        var Promise;
+
+        before(function() {
+            Promise = window.Promise || require('promise');
+        });
 
         beforeEach(function(done) {
             _oldReady = localforage.ready;


### PR DESCRIPTION
I updated the whitespace since this revision removed the nested promises, I can put the extra indent back in for the sake of the diff if it's too difficult to read.

Also, I had to add a hook to `test.api.js` to require the Promise lib - once I removed the nested promises, the outer Promise wasn't there to catch an undefined error from the `localforage.ready` stub.
