### PR TITLE
Batch writes

### DIFF
--- a/test/test.component.html
+++ b/test/test.component.html
@@ -32,6 +32,10 @@
     <script src="/test/test.drivers.js"></script>
     <script src="/test/test.iframes.js"></script>
     <script src="/test/test.webworkers.js"></script>
+    <script src="/test/test.taskqueueing.js"></script>
+    <script src="/test/test.taskbatching.js"></script>
+    <script src="/test/test.taskexecution.js"></script>
+
   </head>
   <body>
     <div id="mocha"></div>

--- a/test/test.main.html
+++ b/test/test.main.html
@@ -27,6 +27,9 @@
     <script src="/test/test.drivers.js"></script>
     <script src="/test/test.iframes.js"></script>
     <script src="/test/test.webworkers.js"></script>
+    <script src="/test/test.taskbatching.js"></script>
+    <script src="/test/test.taskexecution.js"></script>
+    <script src="/test/test.taskqueueing.js"></script>
   </head>
   <body>
     <div id="mocha"></div>

--- a/test/test.min.html
+++ b/test/test.min.html
@@ -28,6 +28,9 @@
     <script src="/test/test.drivers.js"></script>
     <script src="/test/test.iframes.js"></script>
     <script src="/test/test.webworkers.js"></script>
+    <script src="/test/test.taskbatching.js"></script>
+    <script src="/test/test.taskexecution.js"></script>
+    <script src="/test/test.taskqueueing.js"></script>
   </head>
   <body>
     <div id="mocha"></div>

--- a/test/test.taskbatching.js
+++ b/test/test.taskbatching.js
@@ -1,0 +1,202 @@
+/* global beforeEach:true, describe:true, expect:true, it:true, Modernizr:true */
+describe('Task Batching', function() {
+    'use strict';
+    var MAX_TIME_TO_ADD_TASK = 150;
+    var SIMULATED_TRANSACTION_TIME = 400;
+
+    beforeEach(function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setDriver(localforage.INDEXEDDB, function() {
+                localforage._batches = []; //This array remembers what batches are being sent
+                                           //to the _updateDatabase stub.
+                localforage._updateDatabase = function(batch) {
+                    localforage._batches.push(batch);
+                    return {
+                        then: function(resolve) {
+                            setTimeout(function() {
+                                resolve();
+                            }, SIMULATED_TRANSACTION_TIME);
+                        }
+                    };
+                };
+                done();
+            });
+        } else {
+            done();
+        }
+    });
+
+    it('Starts a single task within MAX_TIME_TO_ADD_TASK if not running', function(done) {
+        if (Modernizr.indexeddb) {
+            expect(localforage._taskQueue.length).to.be(0);
+            expect(localforage._running).to.be(false);
+            localforage.setItem('foo', 'bar');
+            setTimeout(function() {
+                expect(localforage._running).to.be(true);
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0] instanceof Array).to.be(true);
+                expect(localforage._batches[0].length).to.be(1);
+                expect(localforage._batches[0][0]).to.be.an('object');
+                expect(localforage._batches[0][0].action).to.be('put');
+                expect(localforage._batches[0][0].key).to.be('foo');
+                expect(localforage._batches[0][0].value).to.be('bar');
+                expect(localforage._batches[0][0].resolve).to.be.a('function');
+                expect(localforage._batches[0][0].reject).to.be.a('function');
+
+                expect(localforage._taskQueue.length).to.be(0);
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
+    it('does not execute a single task within MAX_TIME_TO_ADD_TASK if running', function(done) {
+        if (Modernizr.indexeddb) {
+            expect(localforage._taskQueue.length).to.be(0);
+            expect(localforage._running).to.be(false);
+            localforage._running = true;
+            localforage.setItem('foo', 'bar');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(0);
+
+                expect(localforage._taskQueue.length).to.be(1);
+                expect(localforage._taskQueue[0].action).to.be('put');
+                expect(localforage._taskQueue[0].key).to.be('foo');
+                expect(localforage._taskQueue[0].value).to.be('bar');
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
+    it('batches tasks together when possible', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._running = true;
+            localforage.setItem('foo', 'bar');
+            localforage.removeItem('foo1');
+            localforage.setItem('foo2', 'bar2');
+            localforage._running = false;
+            localforage.removeItem('foo3');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0].length).to.be(4);
+                expect(localforage._batches[0][0].action).to.be('put');
+                expect(localforage._batches[0][0].key).to.be('foo');
+                expect(localforage._batches[0][0].value).to.be('bar');
+                expect(localforage._batches[0][1].action).to.be('delete');
+                expect(localforage._batches[0][1].key).to.be('foo1');
+                expect(localforage._batches[0][2].action).to.be('put');
+                expect(localforage._batches[0][2].key).to.be('foo2');
+                expect(localforage._batches[0][2].value).to.be('bar2');
+                expect(localforage._batches[0][3].action).to.be('delete');
+                expect(localforage._batches[0][3].key).to.be('foo3');
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
+    it('stops before an already affected key', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._running = true;
+            localforage.setItem('foo', 'bar');
+            localforage.removeItem('foo1');
+            localforage.setItem('foo1', 'bar1');
+            localforage._running = false;
+            localforage.removeItem('foo3');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0].length).to.be(2);
+                expect(localforage._batches[0][0].action).to.be('put');
+                expect(localforage._batches[0][0].key).to.be('foo');
+                expect(localforage._batches[0][0].value).to.be('bar');
+                expect(localforage._batches[0][1].action).to.be('delete');
+                expect(localforage._batches[0][1].key).to.be('foo1');
+
+                expect(localforage._taskQueue.length).to.be(2);
+                expect(localforage._taskQueue[0].action).to.be('put');
+                expect(localforage._taskQueue[0].key).to.be('foo1');
+                expect(localforage._taskQueue[0].value).to.be('bar1');
+                expect(localforage._taskQueue[1].action).to.be('delete');
+                expect(localforage._taskQueue[1].key).to.be('foo3');
+                localforage._taskQueue = [];
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
+    it('stops before a clear', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._running = true;
+            localforage.setItem('foo', 'bar');
+            localforage.removeItem('foo1');
+            localforage.clear();
+            localforage._running = false;
+            localforage.removeItem('foo3');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0].length).to.be(2);
+                expect(localforage._batches[0][0].action).to.be('put');
+                expect(localforage._batches[0][0].key).to.be('foo');
+                expect(localforage._batches[0][0].value).to.be('bar');
+                expect(localforage._batches[0][1].action).to.be('delete');
+                expect(localforage._batches[0][1].key).to.be('foo1');
+
+                expect(localforage._taskQueue.length).to.be(2);
+                expect(localforage._taskQueue[0].action).to.be('clear');
+                expect(localforage._taskQueue[1].action).to.be('delete');
+                expect(localforage._taskQueue[1].key).to.be('foo3');
+                localforage._taskQueue = [];
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
+    it('executes a clear separately', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._running = true;
+            localforage.clear();
+            localforage.setItem('foo', 'bar');
+            localforage.removeItem('foo1');
+            localforage._running = false;
+            localforage.removeItem('foo3');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0].length).to.be(1);
+                expect(localforage._batches[0][0].action).to.be('clear');
+
+                expect(localforage._taskQueue.length).to.be(3);
+                expect(localforage._taskQueue[0].action).to.be('put');
+                expect(localforage._taskQueue[0].key).to.be('foo');
+                expect(localforage._taskQueue[0].value).to.be('bar');
+                expect(localforage._taskQueue[1].action).to.be('delete');
+                expect(localforage._taskQueue[1].key).to.be('foo1');
+                expect(localforage._taskQueue[2].action).to.be('delete');
+                expect(localforage._taskQueue[2].key).to.be('foo3');
+                localforage._taskQueue = [];
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+});

--- a/test/test.taskbatching.js
+++ b/test/test.taskbatching.js
@@ -75,6 +75,35 @@ describe('Task Batching', function() {
         }
     });
 
+    it('does not start a batch-of-one, even when not running', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._running = false;
+            localforage.setItem('foo', 'bar');
+            localforage.removeItem('foo1');
+            localforage.setItem('foo2', 'bar2');
+            localforage.removeItem('foo3');
+            setTimeout(function() {
+                expect(localforage._batches.length).to.be(1);
+                expect(localforage._batches[0].length).to.be(4);
+                expect(localforage._batches[0][0].action).to.be('put');
+                expect(localforage._batches[0][0].key).to.be('foo');
+                expect(localforage._batches[0][0].value).to.be('bar');
+                expect(localforage._batches[0][1].action).to.be('delete');
+                expect(localforage._batches[0][1].key).to.be('foo1');
+                expect(localforage._batches[0][2].action).to.be('put');
+                expect(localforage._batches[0][2].key).to.be('foo2');
+                expect(localforage._batches[0][2].value).to.be('bar2');
+                expect(localforage._batches[0][3].action).to.be('delete');
+                expect(localforage._batches[0][3].key).to.be('foo3');
+                setTimeout(function() {
+                    done();
+                }, SIMULATED_TRANSACTION_TIME);
+            }, MAX_TIME_TO_ADD_TASK);
+        } else {
+            done();
+        }
+    });
+
     it('batches tasks together when possible', function(done) {
         if (Modernizr.indexeddb) {
             localforage._running = true;

--- a/test/test.taskexecution.js
+++ b/test/test.taskexecution.js
@@ -1,0 +1,88 @@
+/* global beforeEach:true, describe:true, expect:true, it:true, Modernizr:true */
+describe('Task Execution', function() {
+    'use strict';
+
+    beforeEach(function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setDriver(localforage.INDEXEDDB, function() {
+                done();
+            });
+        } else {
+            done();
+        }
+    });
+
+    it('can execute a setItem (put) task', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._updateDatabase([
+                {
+                    action: 'clear'
+                }
+            ]).then(function() {
+                return localforage._updateDatabase([
+                    {
+                        action: 'put',
+                        key: 'foo',
+                        value: 'bar'
+                    }
+                ]);
+            }).then(function() {
+                 localforage.getItem('foo', function(err, value) {
+                     expect(value).to.be('bar');
+                     // continued in next test!
+                     done();
+                 });
+             });
+        } else {
+            done();
+        }
+    });
+
+    it('can execute a removeItem (delete) task', function(done) {
+        // continued from previous test!
+        if (Modernizr.indexeddb) {
+            localforage._updateDatabase([
+                 {
+                     action: 'delete',
+                     key: 'foo'
+                 }
+             ]).then(function() {
+                 localforage.getItem('foo', function(err, value) {
+                     expect(value).to.be(null);
+                     done();
+                 });
+             });
+        } else {
+            done();
+        }
+    });
+
+    it('can execute a clear task', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage._updateDatabase([
+                 {
+                     action: 'put',
+                     key: 'foo',
+                     value: 'bar'
+                 }
+             ]).then(function() {
+                 localforage.length(function(err, value) {
+                     expect(value).to.be(1);
+                     localforage._updateDatabase([
+                         {
+                             action: 'clear'
+                         }
+                     ]).then(function() {
+                         localforage.length(function(err, value) {
+                             expect(value).to.be(0);
+                             done();
+                         });
+                     });
+                 });
+             });
+        } else {
+            done();
+        }
+    });
+
+});

--- a/test/test.taskqueueing.js
+++ b/test/test.taskqueueing.js
@@ -1,0 +1,177 @@
+/* global beforeEach:true, describe:true, expect:true, it:true, Modernizr:true */
+describe('Task Queueing', function() {
+    'use strict';
+
+    beforeEach(function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setDriver(localforage.INDEXEDDB, function() {
+                localforage._nextBatch = function() {
+                };
+                done();
+            });
+        } else {
+            done();
+        }
+    });
+
+    it('the _taskQueue is initially empty', function(done) {
+        if (Modernizr.indexeddb) {
+            expect(localforage._taskQueue instanceof Array).to.be(true);
+            expect(localforage._taskQueue.length).to.be(0);
+        }
+        done();
+    });
+
+    it('does not queue getItem tasks', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.getItem('foo');
+            expect(localforage._taskQueue.length).to.be(0);
+        }
+        done();
+    });
+
+    it('queues setItem tasks synchronously', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar');
+            expect(localforage._taskQueue.length).to.be(1);
+            expect(localforage._taskQueue[0]).to.be.an('object');
+            expect(localforage._taskQueue[0].action).to.be('put');
+            expect(localforage._taskQueue[0].key).to.be('foo');
+            expect(localforage._taskQueue[0].value).to.be('bar');
+            expect(localforage._taskQueue[0].resolve).to.be.a('function');
+            expect(localforage._taskQueue[0].reject).to.be.a('function');
+        }
+        done();
+    });
+
+    it('queues removeItem tasks synchronously', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.removeItem('foo');
+            expect(localforage._taskQueue.length).to.be(1);
+            expect(localforage._taskQueue[0]).to.be.an('object');
+            expect(localforage._taskQueue[0].action).to.be('delete');
+            expect(localforage._taskQueue[0].key).to.be('foo');
+            expect(localforage._taskQueue[0].resolve).to.be.a('function');
+            expect(localforage._taskQueue[0].reject).to.be.a('function');
+        }
+        done();
+    });
+
+    it('queues clear tasks synchronously', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.clear();
+            expect(localforage._taskQueue.length).to.be(1);
+            expect(localforage._taskQueue[0]).to.be.an('object');
+            expect(localforage._taskQueue[0].action).to.be('clear');
+            expect(localforage._taskQueue[0].resolve).to.be.a('function');
+            expect(localforage._taskQueue[0].reject).to.be.a('function');
+        }
+        done();
+    });
+
+    it('resolves tasks when they succeed [CALLBACK]', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar', function(err, result) {
+                expect(err).to.be(null);
+                expect(result).to.be('yep');
+                done();
+            });
+            localforage._taskQueue[0].resolve('yep');
+        } else {
+            done();
+        }
+    });
+
+    it('rejects tasks when they fail [CALLBACK]', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar', function(err) {
+                expect(err).to.be('nope');
+                done();
+            });
+            localforage._taskQueue[0].reject('nope');
+        } else {
+            done();
+        }
+    });
+
+    it('resolves tasks when they succeed [PROMISE]', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar').then(function(result) {
+                expect(result).to.be('yep');
+                done();
+            }, function() {
+                expect('get here').to.be(false);
+            });
+            localforage._taskQueue[0].resolve('yep');
+        } else {
+            done();
+        }
+    });
+
+    it('rejects tasks when they fail [PROMISE]', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar').then(function() {
+                expect('get here').to.be(false);
+            }, function(err) {
+                expect(err).to.be('nope');
+                done();
+            });
+            localforage._taskQueue[0].reject('nope');
+        } else {
+            done();
+        }
+    });
+
+    it('can queue multiple requests', function(done) {
+        if (Modernizr.indexeddb) {
+            localforage.setItem('foo', 'bar').then(function() {
+                expect('get here').to.be(false);
+            }, function(err) {
+                expect(err).to.be('nope1');
+            });
+            localforage.setItem('foo2', 'bar2').then(function() {
+                expect('get here').to.be(false);
+            }, function(err) {
+                expect(err).to.be('nope2');
+            });
+            localforage.clear().then(function() {
+            }, function() {
+                expect('get here').to.be(false);
+            });
+            localforage.removeItem('foo').then(function() {
+                done();
+            }, function() {
+                expect('get here').to.be(false);
+            });
+            localforage.clear(function(err) {
+                expect(err).to.be('nope3');
+                done();
+            });
+            expect(localforage._taskQueue.length).to.be(5);
+
+            expect(localforage._taskQueue[0].action).to.be('put');
+            expect(localforage._taskQueue[0].key).to.be('foo');
+            expect(localforage._taskQueue[0].value).to.be('bar');
+
+            expect(localforage._taskQueue[1].action).to.be('put');
+            expect(localforage._taskQueue[1].key).to.be('foo2');
+            expect(localforage._taskQueue[1].value).to.be('bar2');
+
+            expect(localforage._taskQueue[2].action).to.be('clear');
+
+            expect(localforage._taskQueue[3].action).to.be('delete');
+            expect(localforage._taskQueue[3].key).to.be('foo');
+
+            expect(localforage._taskQueue[4].action).to.be('clear');
+
+            localforage._taskQueue[0].reject('nope1');
+            localforage._taskQueue[1].reject('nope2');
+            localforage._taskQueue[2].resolve('yep1');
+            localforage._taskQueue[3].resolve('yep2');
+            localforage._taskQueue[4].reject('nope3');
+        } else {
+            done();
+        }
+    });
+
+});


### PR DESCRIPTION
Batch writes together automatically, without changing the API. Fixes #301.

~~TODO: add tests~~
TODO: ~~find a way to stub indexedDB, so that I can~~ test the [`doTask` and `_updateDatabase` functions](https://github.com/michielbdejong/localForage/blob/batch-writes/src/drivers/indexeddb.js#L128-L179)

Sorry for adding so many private funtions on the asyncStorage object, let me know if there's a better way to do this.

I hope this is more or less what you were expecting, there are obviously other ways to architect the code. I'll be happy to change it if you point me to examples of what it should look like.
