### PR TITLE
fix(promise.js): clarify nopromises with commment

### DIFF
--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -1,6 +1,8 @@
 // This is CommonJS because lie is an external dependency, so Rollup
 // can just ignore it.
-if (typeof Promise === 'undefined' && typeof require !== 'undefined') {
+if (typeof Promise === 'undefined') {
+    // In the "nopromises" build this will just throw if you don't have
+    // a global promise object, but it would throw anyway later.
     require('lie/polyfill');
 }
 export default Promise;


### PR DESCRIPTION
Adds a comment explaining what happened with #562 and removes the unnecessary `require` check.

I'm sorry for #562 - the issue is that my understanding of Bowserify's "exclude" feature was wrong. In the Gruntfile I'm using `exclude: ['lie/polyfill']`, which I assumed meant that the `require()` would become a no-op, but in fact it throws. So wrapping it in the global `Promise` check is indeed the right approach - it has nothing to do with whether `require` is defined globally at runtime (in fact it gets munged to `_dereq_` by derequire in order to make absolutely sure it's not relying on globals).

Sorry for the mess-up, and hope the comment clears things up a bit.
