### PR TITLE
docs(README): suggest typescript `import =` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ installed (eg. `npm install --save-dev babel-plugin-system-import-transformer`).
 To import localForage in TypeScript:
 
 ```javascript
-const localForage:LocalForage = require("localforage");
+import localForage = require("localforage");
 ```
 
 Note that the ES6 style import is not supported for our module type. Check out the following to know why:
+* https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
 * http://stackoverflow.com/questions/29596714/new-es6-syntax-for-importing-commonjs-amd-modules-i-e-import-foo-require
 * http://www.jbrantly.com/es6-modules-with-typescript-and-webpack/
 


### PR DESCRIPTION
This is the suggested way since:
* localforage is a UMD module
* [typescript modules export and import require docs](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
* DefinitelyTyped/DefinitelyTyped#10911 with such typings got merged
  (following the [lead of PouchDB](https://github.com/nolanlawson/pouchdb-ionic-2-typescript-demo/pull/1/files) [typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/pouchdb/pouchdb.d.ts))
* [Test project](https://github.com/thgreasi/localForage-cordovaSQLiteDriver-TestIonic2App)

@dsebastien plz review