### PR TITLE
docs(README):  add notice for compiler options setting for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ installed (eg. `npm install --save-dev babel-plugin-system-import-transformer`).
 
 ## TypeScript
 
+First make sure to have `allowSyntheticDefaultImports` set to `true` for
+`compilerOptions` inside of [**tsconfig.json**](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) file (or `--allowSyntheticDefaultImports` during Command-Line invocation):
+
+```json
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  }
+}
+```
+
 To import localForage in TypeScript v2.0 ([sample repo](https://github.com/thgreasi/localForage-cordovaSQLiteDriver-TestIonic2App)) use:
 
 ```javascript


### PR DESCRIPTION
`allowSyntheticDefaultImports` has been [added][default] in TypeScript 1.8, and set to `true` as default for **jsconfig.json** (not **tsconfig.json**) in tag `2.0.5` Microsoft/TypeScript#10895.

This PR would in addition to comply with #608.

/cc @iamolivinius 

[default]: https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#support-for-default-import-interop-with-systemjs