### PR TITLE
feat: add TypeScript typings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,6 +92,9 @@ module.exports = exports = function(grunt) {
                 '< dist/localforage.nopromises.js > dist/localforage.nopromises.tmp ' +
                 '&& ncp dist/localforage.nopromises.tmp dist/localforage.nopromises.js' +
                 '&& rimraf dist/localforage.nopromises.tmp'
+            },
+            typescript_test: {
+                exec: 'node_modules/.bin/tsc --project typing-tests'
             }
         },
         concat: {
@@ -249,6 +252,7 @@ module.exports = exports = function(grunt) {
         'babel',
         'jshint',
         'jscs',
+        'run:typescript_test',
         'browserify:package_bundling_test',
         'webpack:package_bundling_test',
         'connect:test',

--- a/package.json
+++ b/package.json
@@ -52,11 +52,13 @@
     "rimraf": "^2.5.2",
     "rollupify": "^0.1.0",
     "script-loader": "^0.6.1",
+    "typescript": "^2.0.3",
     "uglify-js": "^2.3.x",
     "webpack": "^1.12.13",
     "webpack-dev-server": "^1.10.1"
   },
   "main": "dist/localforage.js",
+  "typings": "typings/localforage.d.ts",
   "bugs": {
     "url": "http://github.com/localForage/localForage/issues"
   },

--- a/typing-tests/localforage-tests.ts
+++ b/typing-tests/localforage-tests.ts
@@ -1,0 +1,116 @@
+﻿/// <reference path="../typings/localforage.d.ts" />
+
+declare let localForage: LocalForage;
+
+namespace LocalForageTest {
+    localForage.clear((err: any) => {
+        let newError: any = err;
+    });
+
+    localForage.getSerializer().then((s: LocalForageSerializer) => {
+        let serializer: LocalForageSerializer = s;
+        typeof serializer.bufferToString === "function";
+        typeof serializer.deserialize === "function";
+        typeof serializer.serialize === "function";
+        typeof serializer.stringToBuffer === "function";
+    });
+
+    localForage.iterate((str: string, key: string, num: number) => {
+        let newStr: string = str;
+        let newKey: string = key;
+        let newNum: number = num;
+    });
+
+    localForage.length((err: any, num: number) => {
+        let newError: any = err;
+        let newNumber: number = num;
+    });
+
+    localForage.length().then((num: number) => {
+        var newNumber: number = num;
+    });
+
+    localForage.key(0, (err: any, value: string) => {
+        let newError: any = err;
+        let newValue: string = value;
+    });
+
+    localForage.keys((err: any, keys: Array<string>) => {
+        let newError: any = err;
+        let newArray: Array<string> = keys;
+    });
+
+    localForage.keys().then((keys: Array<string>) => {
+        var newArray: Array<string> = keys;
+    });
+
+    localForage.getItem("key",(err: any, str: string) => {
+        let newError: any = err;
+        let newStr: string = str
+    });
+
+    localForage.getItem<string>("key").then((str: string) => {
+        let newStr: string = str;
+    });
+
+    localForage.setItem("key", "value",(err: any, str: string) => {
+        let newError: any = err;
+        let newStr: string = str
+    });
+
+    localForage.setItem("key", "value").then((str: string) => {
+        let newStr: string = str;
+    });
+
+    localForage.removeItem("key",(err: any) => {
+        let newError: any = err;
+    });
+
+    localForage.removeItem("key").then(() => {
+    });
+
+    localForage.getDriver("CustomDriver").then((result: LocalForageDriver) => {
+        var driver: LocalForageDriver = result;
+        // we need to use a variable for proper type guards before TS 2.0
+        var _support = driver._support;
+        if (typeof _support === "function") {
+            // _support = _support.bind(driver);
+            _support().then((result: boolean) => {
+                let doesSupport: boolean = result;
+            });
+        } else if (typeof _support === "boolean") {
+            let doesSupport: boolean = _support;
+        }
+    });
+
+    {
+        let config: boolean;
+
+        config = localForage.config({
+            name: "testyo",
+            driver: localForage.LOCALSTORAGE
+        });
+    }
+
+    {
+        let store: LocalForage;
+
+        store = localForage.createInstance({
+            name: "da instance",
+            driver: localForage.LOCALSTORAGE
+        });
+    }
+
+    {
+        let testSerializer: LocalForageSerializer;
+
+        localForage.getSerializer()
+        .then((serializer: LocalForageSerializer) => {
+            testSerializer = serializer;
+        });
+
+        localForage.getSerializer((serializer: LocalForageSerializer) => {
+            testSerializer = serializer;
+        });
+    }
+}

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "target": "es5"
+  },
+  "files": [
+    "../typings/localforage.d.ts",
+    "./localforage-tests.ts"
+  ]
+}

--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -1,0 +1,111 @@
+
+interface LocalForageOptions {
+    driver?: string | string[];
+
+    name?: string;
+
+    size?: number;
+
+    storeName?: string;
+
+    version?: number;
+
+    description?: string;
+}
+
+interface LocalForageDbMethods {
+    getItem<T>(key: string): Promise<T>;
+    getItem<T>(key: string, callback: (err: any, value: T) => void): void;
+
+    setItem<T>(key: string, value: T): Promise<T>;
+    setItem<T>(key: string, value: T, callback: (err: any, value: T) => void): void;
+
+    removeItem(key: string): Promise<void>;
+    removeItem(key: string, callback: (err: any) => void): void;
+
+    clear(): Promise<void>;
+    clear(callback: (err: any) => void): void;
+
+    length(): Promise<number>;
+    length(callback: (err: any, numberOfKeys: number) => void): void;
+
+    key(keyIndex: number): Promise<string>;
+    key(keyIndex: number, callback: (err: any, key: string) => void): void;
+
+    keys(): Promise<string[]>;
+    keys(callback: (err: any, keys: string[]) => void): void;
+
+    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any): Promise<any>;
+    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any,
+            callback: (err: any, result: any) => void): void;
+}
+
+interface LocalForageDriverSupportFunc {
+    (): Promise<boolean>;
+}
+
+interface LocalForageDriver extends LocalForageDbMethods {
+    _driver: string;
+
+    _initStorage(options: LocalForageOptions): void;
+
+    _support: boolean | LocalForageDriverSupportFunc;
+}
+
+interface LocalForageSerializer {
+    serialize<T>(value: T | ArrayBuffer | Blob, callback: (value: string, error: any) => {}): void;
+
+    deserialize<T>(value: string): T | ArrayBuffer | Blob;
+
+    stringToBuffer(serializedString: string): ArrayBuffer;
+
+    bufferToString(buffer: ArrayBuffer): string;
+}
+
+interface LocalForage extends LocalForageDbMethods {
+    LOCALSTORAGE: string;
+    WEBSQL: string;
+    INDEXEDDB: string;
+
+    /**
+    * Set and persist localForage options. This must be called before any other calls to localForage are made, but can be called after localForage is loaded.
+    * If you set any config values with this method they will persist after driver changes, so you can call config() then setDriver()
+    * @param {ILocalForageConfig} options?
+    */
+    config(options: LocalForageOptions): boolean;
+    config(options: string): any;
+    config(): LocalForageOptions;
+
+    /**
+     * Create a new instance of localForage to point to a different store.
+     * All the configuration options used by config are supported.
+     * @param {LocalForageOptions} options
+     */
+    createInstance(options: LocalForageOptions): LocalForage;
+
+    driver(): string;
+    /**
+    * Force usage of a particular driver or drivers, if available.
+    * @param {string} driver
+    */
+    setDriver(driver: string | string[]): Promise<void>;
+    setDriver(driver: string | string[], callback: () => void, errorCallback: (error: any) => void): void;
+
+    defineDriver(driver: LocalForageDriver): Promise<void>;
+    defineDriver(driver: LocalForageDriver, callback: () => void, errorCallback: (error: any) => void): void;
+    /**
+    * Return a particular driver
+    * @param {string} driver
+    */
+    getDriver(driver: string): Promise<LocalForageDriver>;
+
+    getSerializer(): Promise<LocalForageSerializer>;
+    getSerializer(callback: (serializer: LocalForageSerializer) => void): void;
+
+    supports(driverName: string): boolean;
+}
+
+declare module "localforage" {
+    let localforage: LocalForage;
+    export = localforage;
+}


### PR DESCRIPTION
Resolves #600.
Should not be published as a bugfix release of 1.4.x,
since it will cause duplicate definition errors for TypeScript users that already use @types.
We should probably release this as v1.5.0.

As an extra future idea for TypeScript testing, we could change the API tests instead and possibly use the compilation result on the test runner.