### PR TITLE
Use node 6 on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 .yardoc
 _yardoc
 doc/
+
+# typescript cache
+.tscache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
 - bower install
 language: node_js
 node_js:
-- '0.10'
+- '6'
 env:
   global:
     secure: LSmHs32nmcjgp3/5hQASgIPUDF/zexvwV/XASRYCDkwJRllDZ8n8wIvHx+D1QVcotx7jSAVEKM2tcfMq/JLXVHUmNNpeG9maUMfZAHA7xFlAo5GNAG3p/rqYe3tan9Xum+Is6A71kXTVnaVyOTG5ApEyj8QUwPfHpv1ziGJu72Y=


### PR DESCRIPTION
Avoids this error:

````
/home/travis/build/localForage/localForage/node_modules/grunt-rollup/node_modules/rollup/dist/rollup.js:62
	for ( var item of map.entries() ) {
	               ^^
Loading "rollup.js" tasks...ERROR
>> SyntaxError: Unexpected identifier