### PR TITLE
Added Generics to iterate function

### DIFF
--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -35,9 +35,9 @@ interface LocalForageDbMethods {
     keys(): Promise<string[]>;
     keys(callback: (err: any, keys: string[]) => void): void;
 
-    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any): Promise<any>;
-    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any,
-            callback: (err: any, result: any) => void): void;
+    iterate<T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U): Promise<U>;
+    iterate<T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U,
+            callback: (err: any, result: U) => void): void;
 }
 
 interface LocalForageDriverSupportFunc {


### PR DESCRIPTION
Replacing any with generics to improve typ strength. This way the function that is passes as a parameter will be checked if it returns the expected output and type information from iteratee to callback function are "passed".