### PR TITLE
Add missing require module name in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/localForage/localForage.git"
   },
   "scripts": {
-    "build": "node -e \"require('').cli()\" null build",
+    "build": "node -e \"require('grunt').cli()\" null build",
     "publish-docs": "node -e \"require('grunt').cli()\" null copy build-rules-html publish-rules",
     "serve": "node -e \"require('grunt').cli()\" null serve",
     "test": "node -e \"require('grunt').cli()\" null test"


### PR DESCRIPTION
I made this pull request to add the `grunt` module name in build script string in the package.json. It makes the build script run properly as it was previously failing because of the missing name.

I use this package.json scripts a lot, as they are pretty handy when you try to install as less global packages as possible.

Thank you!