### PR TITLE
Increase performance of localStorage keys() function.

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -156,8 +156,9 @@ function keys(callback) {
         var keys = [];
 
         for (var i = 0; i < length; i++) {
-            if (localStorage.key(i).indexOf(dbInfo.keyPrefix) === 0) {
-                keys.push(localStorage.key(i).substring(dbInfo.keyPrefix.length));
+            var itemKey = localStorage.key(i);
+            if (itemKey.indexOf(dbInfo.keyPrefix) === 0) {
+                keys.push(itemKey.substring(dbInfo.keyPrefix.length));
             }
         }
 


### PR DESCRIPTION
[JS Perf Benchmark](https://jsperf.com/localstorage-key-speed )

Original function called localStorage.key(i) twice, which approximately halves performance.