### PR TITLE
Fix dropInstance Typings

### DIFF
--- a/typing-tests/localforage-tests.ts
+++ b/typing-tests/localforage-tests.ts
@@ -1,6 +1,6 @@
-﻿/// <reference path="../typings/localforage.d.ts" />
+﻿import * as localforage from 'localforage';
 
-declare let localForage: LocalForage;
+let localForage: LocalForage = localforage;
 
 namespace LocalForageTest {
     localForage.clear((err: any) => {
@@ -126,6 +126,51 @@ namespace LocalForageTest {
     localForage.removeItem("key").then(() => {
     });
 
+    const customDriver: LocalForageDriver = {
+        _driver: "CustomDriver",
+        _initStorage: (options: LocalForageOptions) => {},
+        getItem: <T>(key: string, callback?: (err: any, value: T) => void) => Promise.resolve({} as T),
+        setItem: <T>(key: string, value: T, callback?: (err: any, value: T) => void) => Promise.resolve(value),
+        removeItem: (key: string, callback?: (err: any) => void) => Promise.resolve(),
+        clear: (callback?: (err: any) => void) => Promise.resolve(),
+        length: (callback?: (err: any, numberOfKeys: number) => void) => Promise.resolve(5),
+        key: (keyIndex: number, callback?: (err: any, key: string) => void) => Promise.resolve('aKey'),
+        keys: (callback?: (err: any, keys: string[]) => void) => Promise.resolve(['1', '2']),
+        iterate: <T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U, callback?: (err: any, result: U) => void) => Promise.resolve({} as U),
+    };
+    localForage.defineDriver(customDriver);
+
+    const customDriver2: LocalForageDriver = {
+        _driver: "CustomDriver",
+        _initStorage: (options: LocalForageOptions) => {},
+        _support: true,
+        getItem: <T>(key: string, callback?: (err: any, value: T) => void) => Promise.resolve({} as T),
+        setItem: <T>(key: string, value: T, callback?: (err: any, value: T) => void) => Promise.resolve(value),
+        removeItem: (key: string, callback?: (err: any) => void) => Promise.resolve(),
+        clear: (callback?: (err: any) => void) => Promise.resolve(),
+        length: (callback?: (err: any, numberOfKeys: number) => void) => Promise.resolve(5),
+        key: (keyIndex: number, callback?: (err: any, key: string) => void) => Promise.resolve('aKey'),
+        keys: (callback?: (err: any, keys: string[]) => void) => Promise.resolve(['1', '2']),
+        iterate: <T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U, callback?: (err: any, result: U) => void) => Promise.resolve({} as U),
+    };
+    localForage.defineDriver(customDriver2);
+
+    const customDriver3: LocalForageDriver = {
+        _driver: "CustomDriver",
+        _initStorage: (options: LocalForageOptions) => {},
+        _support: () => Promise.resolve(true),
+        getItem: <T>(key: string, callback?: (err: any, value: T) => void) => Promise.resolve({} as T),
+        setItem: <T>(key: string, value: T, callback?: (err: any, value: T) => void) => Promise.resolve(value),
+        removeItem: (key: string, callback?: (err: any) => void) => Promise.resolve(),
+        clear: (callback?: (err: any) => void) => Promise.resolve(),
+        length: (callback?: (err: any, numberOfKeys: number) => void) => Promise.resolve(5),
+        key: (keyIndex: number, callback?: (err: any, key: string) => void) => Promise.resolve('aKey'),
+        keys: (callback?: (err: any, keys: string[]) => void) => Promise.resolve(['1', '2']),
+        iterate: <T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U, callback?: (err: any, result: U) => void) => Promise.resolve({} as U),
+        dropInstance: (dbInstanceOptions?: LocalForageDbInstanceOptions, callback?: (err: any) => void) => Promise.resolve(),
+    };
+    localForage.defineDriver(customDriver3);
+
     localForage.getDriver("CustomDriver").then((result: LocalForageDriver) => {
         var driver: LocalForageDriver = result;
         // we need to use a variable for proper type guards before TS 2.0
@@ -143,6 +188,12 @@ namespace LocalForageTest {
     {
         let config: boolean;
 
+        const configOptions: LocalForageOptions = {
+            name: "testyo",
+            driver: localForage.LOCALSTORAGE
+        };
+
+        config = localForage.config(configOptions);
         config = localForage.config({
             name: "testyo",
             driver: localForage.LOCALSTORAGE
@@ -152,10 +203,40 @@ namespace LocalForageTest {
     {
         let store: LocalForage;
 
+        const configOptions: LocalForageOptions = {
+            name: "da instance",
+            driver: localForage.LOCALSTORAGE
+        };
+
+        store = localForage.createInstance(configOptions);
         store = localForage.createInstance({
             name: "da instance",
             driver: localForage.LOCALSTORAGE
         });
+    }
+
+    {
+        localForage.dropInstance().then(() => {});
+
+        const dropInstanceOptions: LocalForageDbInstanceOptions = {
+            name: "da instance",
+            storeName: "da store"
+        };
+
+        localForage.dropInstance(dropInstanceOptions).then(() => {});
+
+        localForage.dropInstance({
+            name: "da instance",
+            storeName: "da store"
+        }).then(() => {});
+
+        const dropDbOptions: LocalForageDbInstanceOptions = {
+            name: "da instance",
+        };
+
+        localForage.dropInstance({
+            name: "da instance",
+        }).then(() => {});
     }
 
     {

--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -1,53 +1,59 @@
-
-interface LocalForageOptions {
-    driver?: string | string[];
-
+interface LocalForageDbInstanceOptions {
     name?: string;
 
-    size?: number;
-
     storeName?: string;
+}
+
+interface LocalForageOptions extends LocalForageDbInstanceOptions {
+    driver?: string | string[];
+
+    size?: number;
 
     version?: number;
 
     description?: string;
 }
 
-interface LocalForageDbMethods {
-    getItem<T>(key: string): Promise<T>;
-    getItem<T>(key: string, callback: (err: any, value: T) => void): void;
+interface LocalForageDbMethodsCore {
+    getItem<T>(key: string, callback?: (err: any, value: T) => void): Promise<T>;
 
-    setItem<T>(key: string, value: T): Promise<T>;
-    setItem<T>(key: string, value: T, callback: (err: any, value: T) => void): void;
+    setItem<T>(key: string, value: T, callback?: (err: any, value: T) => void): Promise<T>;
 
-    removeItem(key: string): Promise<void>;
-    removeItem(key: string, callback: (err: any) => void): void;
+    removeItem(key: string, callback?: (err: any) => void): Promise<void>;
 
-    clear(): Promise<void>;
-    clear(callback: (err: any) => void): void;
+    clear(callback?: (err: any) => void): Promise<void>;
 
-    length(): Promise<number>;
-    length(callback: (err: any, numberOfKeys: number) => void): void;
+    length(callback?: (err: any, numberOfKeys: number) => void): Promise<number>;
 
-    key(keyIndex: number): Promise<string>;
-    key(keyIndex: number, callback: (err: any, key: string) => void): void;
+    key(keyIndex: number, callback?: (err: any, key: string) => void): Promise<string>;
 
-    keys(): Promise<string[]>;
-    keys(callback: (err: any, keys: string[]) => void): void;
+    keys(callback?: (err: any, keys: string[]) => void): Promise<string[]>;
 
-    iterate<T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U): Promise<U>;
     iterate<T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U,
-            callback: (err: any, result: U) => void): void;
-
-    dropInstance(callback?: (err: any) => void): Promise<void>;
-    dropInstance(dbInstanceOptions?: LocalForageOptions, callback?: (err: any) => void): Promise<void>;
+            callback?: (err: any, result: U) => void): Promise<U>;
 }
+
+interface LocalForageDropInstanceFn {
+    (dbInstanceOptions?: LocalForageDbInstanceOptions, callback?: (err: any) => void): Promise<void>;
+}
+
+interface LocalForageDriverMethodsOptional {
+    dropInstance?: LocalForageDropInstanceFn;
+}
+
+// duplicating LocalForageDriverMethodsOptional to preserve TS v2.0 support,
+// since Partial<> isn't supported there
+interface LocalForageDbMethodsOptional {
+    dropInstance: LocalForageDropInstanceFn;
+}
+
+interface LocalForageDriverDbMethods extends LocalForageDbMethodsCore, LocalForageDriverMethodsOptional {}
 
 interface LocalForageDriverSupportFunc {
     (): Promise<boolean>;
 }
 
-interface LocalForageDriver extends LocalForageDbMethods {
+interface LocalForageDriver extends LocalForageDriverDbMethods {
     _driver: string;
 
     _initStorage(options: LocalForageOptions): void;
@@ -64,6 +70,8 @@ interface LocalForageSerializer {
 
     bufferToString(buffer: ArrayBuffer): string;
 }
+
+interface LocalForageDbMethods extends LocalForageDbMethodsCore, LocalForageDbMethodsOptional {}
 
 interface LocalForage extends LocalForageDbMethods {
     LOCALSTORAGE: string;
@@ -87,28 +95,26 @@ interface LocalForage extends LocalForageDbMethods {
     createInstance(options: LocalForageOptions): LocalForage;
 
     driver(): string;
+
     /**
      * Force usage of a particular driver or drivers, if available.
      * @param {string} driver
      */
-    setDriver(driver: string | string[]): Promise<void>;
-    setDriver(driver: string | string[], callback: () => void, errorCallback: (error: any) => void): void;
+    setDriver(driver: string | string[], callback?: () => void, errorCallback?: (error: any) => void): Promise<void>;
 
-    defineDriver(driver: LocalForageDriver): Promise<void>;
-    defineDriver(driver: LocalForageDriver, callback: () => void, errorCallback: (error: any) => void): void;
+    defineDriver(driver: LocalForageDriver, callback?: () => void, errorCallback?: (error: any) => void): Promise<void>;
+
     /**
      * Return a particular driver
      * @param {string} driver
      */
     getDriver(driver: string): Promise<LocalForageDriver>;
 
-    getSerializer(): Promise<LocalForageSerializer>;
-    getSerializer(callback: (serializer: LocalForageSerializer) => void): void;
+    getSerializer(callback?: (serializer: LocalForageSerializer) => void): Promise<LocalForageSerializer>;
 
     supports(driverName: string): boolean;
 
-    ready(callback: (error: any) => void): void;
-    ready(): Promise<void>;
+    ready(callback?: (error: any) => void): Promise<void>;
 }
 
 declare module "localforage" {


### PR DESCRIPTION
Resolves #762
Makes dropInstance an optional method for driver objects.
Combines all callback method overloads, marking the callback argument as optional, which is closer to how LF works.