### PR TITLE
[IndexedDB]: Pass in decoded Blob setItem to callbacks and promises

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -656,6 +656,10 @@ function setItem(key, value, callback) {
                                 value = null;
                             }
 
+                            if (_isEncodedBlob(value)) {
+                                value = _decodeBlob(value);
+                            }
+
                             resolve(value);
                         };
                         transaction.onabort = transaction.onerror = function() {

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -399,7 +399,11 @@ DRIVERS.forEach(function(driverName) {
                             done(e);
                         }
                     })
-                    .then(function() {
+                    .then(function(blob) {
+                        expect(blob.toString()).to.be('[object Blob]');
+                        expect(blob.size).to.be(testBlob.size);
+                        expect(blob.type).to.be(testBlob.type);
+
                         localforage.getItem('blob', function(err, blob) {
                             expect(err).to.be(null);
                             expect(blob.toString()).to.be('[object Blob]');

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -404,14 +404,15 @@ DRIVERS.forEach(function(driverName) {
                         expect(blob.size).to.be(testBlob.size);
                         expect(blob.type).to.be(testBlob.type);
 
-                        localforage.getItem('blob', function(err, blob) {
+                        return localforage.getItem('blob', function(err, blob) {
                             expect(err).to.be(null);
                             expect(blob.toString()).to.be('[object Blob]');
                             expect(blob.size).to.be(testBlob.size);
                             expect(blob.type).to.be(testBlob.type);
                             done();
                         });
-                    });
+                    })
+                    .catch(done);
             });
         } else {
             it.skip('saves binary (Blob) data (Blob type does not exist)');

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -387,10 +387,17 @@ DRIVERS.forEach(function(driverName) {
 
                 localforage
                     .setItem('blob', testBlob, function(err, blob) {
-                        expect(err).to.be(null);
-                        expect(blob.toString()).to.be('[object Blob]');
-                        expect(blob.size).to.be(testBlob.size);
-                        expect(blob.type).to.be(testBlob.type);
+                        try {
+                            expect(err).to.be(null);
+                            expect(blob.toString()).to.be('[object Blob]');
+                            expect(blob.size).to.be(testBlob.size);
+                            expect(blob.type).to.be(testBlob.type);
+                            done();
+                        } catch (e) {
+                            // Fail immediately instead of on timeout
+                            // Note: exception in this callback does not fail the promise, see #777
+                            done(e);
+                        }
                     })
                     .then(function() {
                         localforage.getItem('blob', function(err, blob) {


### PR DESCRIPTION
...instead of the string-encoded ones (when the underlying IndexedDB does not support storing Blobs).

A test already existed verifying this but it was broken due to #777. Improved the tests in separate commits (made them fail) related to this fix but a thorough review of the whole test suite would be useful to spot further assertions that never fail tests.