### PR TITLE
#658 add documentation for version configuration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -367,7 +367,7 @@ Set and persist localForage options. This must be called *before* any other call
   </dd>
   <dt>version</dt>
   <dd>
-    The version of your database. May be used for upgrades in the future; currently unused.<br>
+    The schema version of your database. Used only in WebSQL and IndexedDB. In WebSQL, this simply sets the version, and in IndexedDB this may trigger an <code>onupgradeneeded</code> event if a version upgrade is detected. If a new store is detected, localForage will ask IndexedDB to increment the version itself to manually trigger the <code>onupgradeneeded</code> event. As of right now, upgrade events are not customizable, but may be in the future. For drivers that do not support configuration for versioning, this value simply gets thrown away.<br>
     Default: <code>1.0</code>
   </dd>
   <dt>description</dt>


### PR DESCRIPTION
From the original issue #658 there was talk about how the `version` configuration actually does do specific things in localForage. Testing locally it does seem we do use it.

In WebSQL, it does seem we pass the configuration in but from there I could not see anything WebSQL does with it. In IndexedDB, it also uses the configuration version set and sets it as IndexedDB's version. If we detect that it was an upgrade (`_isUpgradeNeeded`), we do call a new connection, pass in there was an upgrade and `localForage` will define its own `onupgradeneeded` event which will attempt to recreate the object store. There also seems to be some logic where when a new store is created, it will also trigger this and increment IndexedDB's version by 1 on its own.

I'm not sure if the documentation I wrote clearly suggests all that I wrote so if someone has suggestions for improvements, I'm totally willing to make them! Hope this is accurate from what I can find.

Also FYI two things I didn't document but might be worth mentioning

1) There was a mention of semantic versioning in the PR but I believe it's accurate that we are doing a `typeof number` because nowhere did I find that IndexedDB supports semver so I just tried to be clear that it was a "schema version"

2) If an upgrade is detected, we call `db.createObjectStore(dbInfo.storeName)` which ends up potentially throwing `ConstraintError`. This is actually expected if the user did not clear the original storeName [because `createObjectStore` only can create if its a unique name](https://stackoverflow.com/questions/17770716/constraint-error-on-indexeddb-database-when-updating-version-and-nothing-else#answer-17772759) :/ not sure if this is something that needs to be addressed.