### PR TITLE
Update downloads badge to point to graph of downloads over time 📈

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/localForage/localForage.svg?branch=master)](http://travis-ci.org/localForage/localForage)
 [![NPM version](https://badge.fury.io/js/localforage.svg)](http://badge.fury.io/js/localforage)
 [![Dependency Status](https://img.shields.io/david/localForage/localForage.svg)](https://david-dm.org/localForage/localForage)
-[![npm](https://img.shields.io/npm/dm/localforage.svg?maxAge=2592000)]()
+[![npm](https://img.shields.io/npm/dm/localforage.svg?maxAge=2592000)](https://npmcharts.com/compare/localforage?minimal=true)
 [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/localforage/badge?style=rounded)](https://www.jsdelivr.com/package/npm/localforage)
 
 localForage is a fast and simple storage library for JavaScript. localForage


### PR DESCRIPTION
Hi! I noticed that your "downloads" badge is currently a broken link 

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/localforage?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄