### PR TITLE
Avoid uncaught error in dropInstance onblocked handler

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-  "single-quote": true,
+  "singleQuote": true,
   "tabWidth": 4
 }

--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -198,7 +198,16 @@ function _getConnection(dbInfo, upgradeNeeded) {
         };
 
         openreq.onsuccess = function() {
-            resolve(openreq.result);
+            var db = openreq.result;
+            db.onversionchange = function(e) {
+                // Triggered when the database is modified (e.g. adding an objectStore) or
+                // deleted (even when initiated by other sessions in different tabs).
+                // Closing the connection here prevents those operations from being blocked.
+                // If the database is accessed again later by this instance, the connection
+                // will be reopened or the database recreated as needed.
+                e.target.close();
+            };
+            resolve(db);
             _advanceReadiness(dbInfo);
         };
     });
@@ -984,12 +993,22 @@ function dropInstance(options, callback) {
                 const dropDBPromise = new Promise((resolve, reject) => {
                     var req = idb.deleteDatabase(options.name);
 
-                    req.onerror = req.onblocked = err => {
+                    req.onerror = () => {
                         const db = req.result;
                         if (db) {
                             db.close();
                         }
-                        reject(err);
+                        reject(req.error);
+                    };
+
+                    req.onblocked = () => {
+                        // Closing all open connections in onversionchange handler should prevent this situation, but if
+                        // we do get here, it just means the request remains pending - eventually it will succeed or error
+                        console.warn(
+                            'dropInstance blocked for database "' +
+                                options.name +
+                                '" until all open connections are closed'
+                        );
                     };
 
                     req.onsuccess = () => {


### PR DESCRIPTION
[Context](https://github.com/localForage/localForage/issues/800)

I found I had to make the change to .prettierrc to avoid the precommit step replacing all the ' with "