### PR TITLE
localforage for triple slash reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ import * as localForage from "localforage";
 import localForage = require("localforage");
 ```
 
+Triple slash reference:
+
+```javascript
+/// <reference path="./your/path/to/localforage.d.ts" />
+localforage.config({
+    name: 'Hipster PDA App'
+})
+```
+
 ## Framework Support
 
 If you use a framework listed, there's a localForage storage driver for the

--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -121,3 +121,5 @@ declare module "localforage" {
     let localforage: LocalForage;
     export = localforage;
 }
+
+declare var localforage: LocalForage


### PR DESCRIPTION
It can save a lot of headache a simple new line of code in `localforage.d.ts` for newcomers who want to test/use localForage with typescript. 

`npm install localforage ` or  download `typings/localforage.d.ts` then with triple slash reference point to `localforage.d.ts`.

```javascript
/// <reference path="./path/to/your/your/localforage.d.ts" />
localforage.setItem('key', 'value').then(function () {
  return localforage.getItem('key');
}).then(function (value) {
  // we got our value
}).catch(function (err) {
  // we got an error
});
```