### PR TITLE
Type definitions when dropping .d.ts file into the working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ import * as localForage from "localforage";
 import localForage = require("localforage");
 ```
 
+Drop `localforage.d.ts` into the working folder or use the triple slash reference to point to it:
+```javascript
+/// <reference path="./your/path/to/localforage.d.ts" />
+localforage.config({
+    name: 'Hipster PDA App'
+})
+```
+
 ## Framework Support
 
 If you use a framework listed, there's a localForage storage driver for the

--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -121,3 +121,5 @@ declare module "localforage" {
     let localforage: LocalForage;
     export = localforage;
 }
+
+declare var localforage: LocalForage


### PR DESCRIPTION
It can save a lot of headache a simple new line of code in `localforage.d.ts` for newcomers who want to test/use localForage with typescript.

Drop `typings/localforage.d.ts` file into the working directory or point to it with triple slash reference.

```js
/// <reference path="./path/to/your/your/localforage.d.ts" />
localforage.setItem('key', 'value').then(function () {
  return localforage.getItem('key');
}).then(function (value) {
  // we got our value
}).catch(function (err) {
  // we got an error
});
```