### PR TITLE
minor syntax fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -504,7 +504,7 @@ Creates a new instance of localForage and returns it. Each object contains its o
 
 ```js
 localforage.dropInstance().then(function() {
-  console.log('Dropped the store of the current instance').
+  console.log('Dropped the store of the current instance');
 });
 
 localforage.dropInstance({


### PR DESCRIPTION
The code example for `dropInstance` accidentally used a `.` instead of a `;`