### PR TITLE
Bump husky & lint-staged versions

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,6 @@
+{
+  "{src,test}/**/*.js": [
+    "prettier --write",
+    "git add"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "build": "node -e \"require('grunt').cli()\" null build",
-    "precommit": "lint-staged",
     "prettify": "prettier --write \"src/**/*.js\" \"test/**/*.js\"",
     "publish-docs": "node -e \"require('grunt').cli()\" null copy build-rules-html publish-rules",
     "serve": "node -e \"require('grunt').cli()\" null serve",
@@ -51,8 +50,8 @@
     "grunt-saucelabs": "^5.1.2",
     "grunt-ts": "^6.0.0-beta.11",
     "grunt-webpack": "^1.0.11",
-    "husky": "^0.14.3",
-    "lint-staged": "^5.0.0",
+    "husky": "^2.3.0",
+    "lint-staged": "^8.1.7",
     "load-grunt-tasks": "^0.4.0",
     "mocha": "^3.4.2",
     "phantomjs": "^2.1.7",
@@ -71,11 +70,5 @@
   },
   "dependencies": {
     "lie": "3.1.1"
-  },
-  "lint-staged": {
-    "{src,test}/**/*.js": [
-      "prettier --write",
-      "git add"
-    ]
   }
 }


### PR DESCRIPTION
Also moved their configuration out of the package.json (following the single responsibility principle), which makes the package.json cleaner imo & is also what husky & lint-staged do in their own repos.

See: https://github.com/typicode/husky#upgrading-from-014
See: https://github.com/okonet/lint-staged#lintstagedrc-example