### PR TITLE
Added async/await example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,13 @@ localforage.getItem('somekey').then(function(value) {
     console.log(err);
 });
 
+// Async/await version:
+(async() => {
+    const value = await localforage.getItem('somekey');
+    // This code runs once the value has been loaded
+    // from the offline store.
+})()
+
 // Callback version:
 localforage.getItem('somekey', function(err, value) {
     // Run this code once the value has been


### PR DESCRIPTION
Come on, its 2020, async/await came in ES2017.
Easier to read
I suggest to remove Promises version as it is harder to read