### PR TITLE
docs: Fix simple typo, retuns -> returns

### DIFF
--- a/dist/localforage.js
+++ b/dist/localforage.js
@@ -978,7 +978,7 @@ function iterate(iterator, callback) {
                             }
                             var result = iterator(value, cursor.key, iterationNumber++);
 
-                            // when the iterator callback retuns any
+                            // when the iterator callback returns any
                             // (non-`undefined`) value, then we stop
                             // the iteration immediately
                             if (result !== void 0) {

--- a/dist/localforage.nopromises.js
+++ b/dist/localforage.nopromises.js
@@ -642,7 +642,7 @@ function iterate(iterator, callback) {
                             }
                             var result = iterator(value, cursor.key, iterationNumber++);
 
-                            // when the iterator callback retuns any
+                            // when the iterator callback returns any
                             // (non-`undefined`) value, then we stop
                             // the iteration immediately
                             if (result !== void 0) {

--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -575,7 +575,7 @@ function iterate(iterator, callback) {
                                     iterationNumber++
                                 );
 
-                                // when the iterator callback retuns any
+                                // when the iterator callback returns any
                                 // (non-`undefined`) value, then we stop
                                 // the iteration immediately
                                 if (result !== void 0) {


### PR DESCRIPTION
There is a small typo in dist/localforage.js, dist/localforage.nopromises.js, src/drivers/indexeddb.js.

Should read `returns` rather than `retuns`.

