### PR TITLE
Updated mocha-headless-chrome version to latest in pakcage.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,15 +225,12 @@ module.exports = exports = function(grunt) {
     grunt.registerTask('mocha', 'custom function to run mocha tests', function() {
         const {runner} = require('mocha-headless-chrome');
         const fs   = require('fs');
-        const path = require('path');
         var done = this.async();
         var tempErrLogs = fs.createWriteStream('temp.test.log');
         var oldStdErr = process.stderr.write;
         var totaltestsPassed = 0;
         var totaltestsFailed = 0;
         var totalDuration = 0;
-        var asset = path.join.bind(null, __dirname,
-                    'node_modules/puppeteer/.local-chromium/linux-686378');
         var urls = [
                  'http://localhost:9999/test/test.main1.html',
                  'http://localhost:9999/test/test.min.html',
@@ -254,8 +251,8 @@ module.exports = exports = function(grunt) {
                 reporter: 'dot',                             // mocha reporter name
                 width: 800,                                  // viewport width
                 height: 600,                                 // viewport height
-                timeout: 60000,                              // timeout in ms
-                executablePath: asset('chrome-linux/chrome'),// chrome executable path
+                timeout: 120000,                             // timeout in ms
+                executablePath: null,                        // chrome executable path
                 visible: false,                              // show chrome window
                 args: ['no-sandbox']                         // chrome arguments
             };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-watch": "^0.5.0",
     "grunt-es3-safe-recast": "^0.1.0",
     "grunt-eslint": "^20.0.0",
-    "mocha-headless-chrome": "2.0.3",
+    "mocha-headless-chrome": "3.1.0",
     "grunt-rollup": "^0.6.2",
     "grunt-run": "^0.5.2",
     "grunt-saucelabs": "^5.1.2",

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -1750,7 +1750,7 @@ DRIVERS.forEach(function(driverName) {
 
 SUPPORTED_DRIVERS.forEach(function(driverName) {
     describe(driverName + ' driver dropInstance', function() {
-        this.timeout(30000);
+        this.timeout(80000);
 
         function setCommonOpts(opts) {
             opts.driver = driverName;


### PR DESCRIPTION
Updated mocha-headless-chrome version to latest in package.json as the latest puppeteer version has support for aarch64 platform. Increased the timeout in test.api.js and updated Gruntfile.js to update the chrome executable path.