### PR TITLE
Fixed behaviour of empty key prefix string

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -11,9 +11,9 @@ import normalizeKey from '../utils/normalizeKey';
 import getCallback from '../utils/getCallback';
 
 function _getKeyPrefix(options, defaultConfig) {
-    var keyPrefix = options.name + '/';
+    var keyPrefix = options.name ? options.name + '/' : '';
 
-    if (options.storeName !== defaultConfig.storeName) {
+    if (options.storeName && options.storeName !== defaultConfig.storeName) {
         keyPrefix += options.storeName + '/';
     }
     return keyPrefix;


### PR DESCRIPTION
Hi!

I recently stumpled upon the keyprefix-logic of localforage, when I explicitly didn't want to have a KeyPrefix in my LF instance. Avoiding to define an instance name, will lead to the issue that localforage itself sets the "localforage" prefix. Hence I did

```js
localforage.createInstance({ name: '' });
```

This replaced the name field with an empty string, however e.g. the LocalStorage driver is still pre-prending a slash (/) to the keys I try to get. As it can be seen here: https://github.com/localForage/localForage/blob/c1cc34fda0343c5e19224fc99c452dbe611c1736/src/drivers/localstorage.js#L14

I was wondering if this is a desired behaviour or not. For me it seems to be unwanted and thus I consider it being a bug. This PR will hopefully fix the issue.

I currently further maintain the [ReactNative AsyncStorage Driver for LF](https://github.com/aveq-research/localforage-asyncstorage-driver) as well as the [WebExtension Storage Driver](https://github.com/esphen/localforage-webExtensionStorage-driver). If you also see this as a bug and accept the PR or similar I will also re-check these drivers for the same possible issue in these packages and fix if required.