### PR TITLE
Support detection of indexedDB window variable

### DIFF
--- a/src/utils/isIndexedDBValid.js
+++ b/src/utils/isIndexedDBValid.js
@@ -4,7 +4,7 @@ function isIndexedDBValid() {
     try {
         // Initialize IndexedDB; fall back to vendor-prefixed versions
         // if needed.
-        if (!idb || !idb.open) {
+        if ((!idb || !idb.open) && (!indexedDB || !indexedDB.open)) {
             return false;
         }
         // We mimic PouchDB here;


### PR DESCRIPTION
Support detection of indexedDB window variable using Chrome supported variable name.

This seems to fix some race conditions that cause the indexeddb driver to fail detection and move on to the next configured driver (a very odd situation with little fallback)

On another note, it might be nice to get a console warning or callback when driver fallback has occurred.