### PR TITLE
Fix indexDb driver so pending operations are resolved under concurrent worker threads

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -150,7 +150,8 @@ function _getConnection(dbInfo, upgradeNeeded) {
                 _deferReadiness(dbInfo);
                 dbInfo.db.close();
             } else {
-                return resolve(dbInfo.db);
+                // make sure any defferred operation promises are resolved
+                return _advanceReadiness(dbInfo).then(() => resolve(dbInfo.db));
             }
         }
 


### PR DESCRIPTION
Hi, this is related to:

https://github.com/localForage/localForage/issues/1008

and

https://github.com/localForage/localForage/pull/1009

I am unfortunately unable to run tests against this locally, because the tests appear to be broken per the Issues board (I gave it my best shot, but I don't want to spend too much time on that if they're broken, we should also update the README to reflect they're broken at the moment if they're truly broken), so I'm hoping one of the long time maintainers can look at this and confirm this makes sense.

What this fixes is some operations for the indexedDb  never complete when a new connection is setup. So e.g. if you have two instances for the same storeName and version that are created concurrently (with a worker thread and ur main thread) and both of those instances make pending requests, you can run into a race condition.

So what you end up with are hanging promises, and the promise for let's say a getItem() never resolves. So yeah, generally not good.

Thanks for all the hard work people!

Best,
inF3Rnus

