### PR TITLE
feat(localstorage): allow empty prefix

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -11,7 +11,8 @@ import normalizeKey from '../utils/normalizeKey';
 import getCallback from '../utils/getCallback';
 
 function _getKeyPrefix(options, defaultConfig) {
-    var keyPrefix = options.name + '/';
+    var keyPrefix =
+        options.name && options.name.trim() !== '' ? options.name + '/' : '';
 
     if (options.storeName !== defaultConfig.storeName) {
         keyPrefix += options.storeName + '/';


### PR DESCRIPTION
This PR is a small change in localstorage.js to allow no prefix when store name is not defined.