### PR TITLE
removed extra `code` denotation from docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -67,9 +67,8 @@ localforage.getItem('somekey', function(err, value) {
     console.log(value);
 });
 
-Or, use `async`/`await`:
+// Or, use `async`/`await`:
 
-```js
 try {
     const value = await localforage.getItem('somekey');
     // This code runs once the value has been loaded


### PR DESCRIPTION
## please see the image for a clear understanding

### Issue
![image](https://user-images.githubusercontent.com/58888934/142735670-4388f98f-0208-449a-9083-b50f55932da6.png)
