### PR TITLE
Fixed TS import example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Otherwise you should use one of the following:
 import * as localForage from "localforage";
 // or, in case that the typescript version that you are using
 // doesn't support ES6 style imports for UMD modules like localForage
-import localForage = require("localforage");
+const localForage = require("localforage");
 ```
 
 ## Framework Support


### PR DESCRIPTION
Correct me if I'm wrong, but I believe the example in the README is not valid syntax:

```ts
import localForage = require("localforage");
```

I have changed this to 

```ts
const localForage = require("localforage");
```