### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/docs/scripts/flatdoc.js
+++ b/docs/scripts/flatdoc.js
@@ -266,7 +266,7 @@
 
     $content.find('h1, h2, h3').each(function() {
       var $el = $(this);
-      var level = +(this.nodeName.substr(1));
+      var level = +(this.nodeName.slice(1));
 
       var parent = mkdir_p(level-1);
 
@@ -463,7 +463,7 @@
       }
       var data = Flatdoc.parser.parse(markdown, doc.highlight);
       doc.applyData(data, doc);
-      var id = location.hash.substr(1);
+      var id = location.hash.slice(1);
       if (id) {
         var el = document.getElementById(id);
         if (el) el.scrollIntoView(true);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.