### PR TITLE
Fix: place the fullstops inside of the string called through console.log

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -523,13 +523,13 @@ localforage.dropInstance({
   name: "otherName",
   storeName: "otherStore"
 }).then(function() {
-  console.log('Dropped otherStore').
+  console.log('Dropped otherStore.')
 });
 
 localforage.dropInstance({
   name: "otherName"
 }).then(function() {
-  console.log('Dropped otherName database').
+  console.log('Dropped otherName database.')
 });
 ```
 


### PR DESCRIPTION
The docs example of dropping an instance has a syntax error. This fixes it.