### PR TITLE
Add retry error case for indexeddb

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -369,7 +369,8 @@ function createTransaction(dbInfo, mode, callback, retries) {
             retries > 0 &&
             (!dbInfo.db ||
                 err.name === 'InvalidStateError' ||
-                err.name === 'NotFoundError')
+                err.name === 'NotFoundError' ||
+                err.name === 'UnknownError')
         ) {
             return Promise.resolve()
                 .then(() => {


### PR DESCRIPTION
When an iphone is locked during a transaction and then woken up it can produce the following error: `"UnknownError: Attempt to get a record from database without an in-progress transaction"`

Adding this retry case fixes the issue