### PR TITLE
修复bug: 修复强制设置驱动为LOCALSTORAGE时执行clear可能未全部清除的问题

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -70,12 +70,16 @@ function clear(callback) {
     var promise = self.ready().then(function() {
         var keyPrefix = self._dbInfo.keyPrefix;
 
+        var keys = [];
         for (var i = localStorage.length - 1; i >= 0; i--) {
             var key = localStorage.key(i);
 
             if (key.indexOf(keyPrefix) === 0) {
-                localStorage.removeItem(key);
+                keys.push(key);
             }
+        }
+        for (var j = 0; j < keys.length; j++) {
+            localStorage.removeItem(keys[j]);
         }
     });
 


### PR DESCRIPTION
以下仅指驱动设置为 `localforage.LOCALSTORAGE` 的情况。
以下仅指驱动设置为 `localforage.LOCALSTORAGE` 的情况。
以下仅指驱动设置为 `localforage.LOCALSTORAGE` 的情况。

当我的 `localStorage` 中已储存了一个键值的时候，如键是 `token`，值是 `hello`，此时我使用 localForage 去存储如下值：

```js
localforage.setItem('str', 'Hello World')
localforage.setItem('num', 123)
localforage.setItem('bool', false)
localforage.setItem('arr', [1, 'a', true])
localforage.setItem('obj', { name: 'tom', age: 20, isVip: false })
```

然后我执行 `localforage.clear()` ，这个时候总会又一个 `locaforage` 存储的内容遗留在 `localStorage` 中，我必须再次执行  `localforage.clear()` 才可完全清除。

经自己测试，可将 `localstorage.js` 中的 `clear` 方法改成如下形式，虽然多了一个循环，但不会出现如上问题：

```js
function clear(callback) {
    var self = this;
    var promise = self.ready().then(function() {
        var keyPrefix = self._dbInfo.keyPrefix;

        var keys = [];
        for (var i = localStorage.length - 1; i >= 0; i--) {
            var key = localStorage.key(i);

            if (key.indexOf(keyPrefix) === 0) {
                keys.push(key);
            }
        }
        for (var j = 0; j < keys.length; j++) {
            localStorage.removeItem(keys[j]);
        }
    });

    executeCallback(promise, callback);
    return promise;
}
```