### PR TITLE
Implement methods to transactionally get and set multiple items

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -322,6 +322,8 @@ var localStorageWrapper = {
     getItem: getItem,
     setItem: setItem,
     removeItem: removeItem,
+    getMultipleItems: () => { throw "Method unsupported for driver."; },
+    setMultipleItems: () => { throw "Method unsupported for driver."; },
     clear: clear,
     length: length,
     key: key,

--- a/src/drivers/websql.js
+++ b/src/drivers/websql.js
@@ -600,6 +600,8 @@ var webSQLStorage = {
     getItem: getItem,
     setItem: setItem,
     removeItem: removeItem,
+    getMultipleItems: () => { throw "Method unsupported for driver."; },
+    setMultipleItems: () => { throw "Method unsupported for driver."; },
     clear: clear,
     length: length,
     key: key,

--- a/src/localforage.js
+++ b/src/localforage.js
@@ -36,7 +36,9 @@ const LibraryMethods = [
     'keys',
     'length',
     'removeItem',
-    'setItem'
+    'setItem',
+    'setMultipleItems',
+    'getMultipleItems'
 ].concat(OptionalDriverMethods);
 
 const DefaultConfig = {

--- a/typings/localforage.d.ts
+++ b/typings/localforage.d.ts
@@ -17,7 +17,11 @@ interface LocalForageOptions extends LocalForageDbInstanceOptions {
 interface LocalForageDbMethodsCore {
     getItem<T>(key: string, callback?: (err: any, value: T | null) => void): Promise<T | null>;
 
+    getMultipleItems<T>(keys: ReadonlyArray<keyof T>, synchronizationKey: string): Promise<Readonly<{...T, synchronizationValue?: string}>>;
+
     setItem<T>(key: string, value: T, callback?: (err: any, value: T) => void): Promise<T>;
+
+    setMultipleItems<T>(input: T, synchronizationKey: string, expectedSynchronizationValue?: string, newSynchronizationValue: string, forceWrite: boolean): Promise<void>;
 
     removeItem(key: string, callback?: (err: any) => void): Promise<void>;
 


### PR DESCRIPTION
This PR modifies `localforage` to support transactional multiple item retrieval/persistence. The `synchronizationKey` and `synchronizationValue` arguments are used to handle race conditions. The `setMultipleItems` call will only succeed if current value under `synchronizationKey` in `localforage` is equal to `expectedSynchronizationValue` or `forceWrite` is set to true. This lets us select on thread to always win race condition.

Two methods mentioned above are implemented only for `IndexedDB` driver. 